### PR TITLE
Match ALPRs missing man_made or using multi-value surveillance:type

### DIFF
--- a/worker/src/fetchers/cameras.ts
+++ b/worker/src/fetchers/cameras.ts
@@ -5,8 +5,8 @@ import { pointFeature, buildFeatureCollection } from '../lib/geojson';
 export const CAMERAS_OVERPASS_QUERY = `[out:json][timeout:300];
 area["ISO3166-1"="US"]->.us;
 (
-  node["man_made"="surveillance"]["surveillance:type"="ALPR"](area.us);
-  way["man_made"="surveillance"]["surveillance:type"="ALPR"](area.us);
+  node["surveillance:type"~"(^|;)ALPR($|;)"](area.us);
+  way["surveillance:type"~"(^|;)ALPR($|;)"](area.us);
 );
 out meta;
 >;
@@ -111,9 +111,10 @@ export function transformOverpassToGeoJSON(
   for (const el of data.elements) {
     const tags = el.tags ?? {};
 
-    // Only process surveillance ALPR elements
-    if (tags['man_made'] !== 'surveillance') continue;
-    if (tags['surveillance:type'] !== 'ALPR') continue;
+    // Only process ALPR elements. surveillance:type=ALPR is the defining tag and
+    // may be one of several ;-separated values; man_made=surveillance is not required.
+    const surveillanceTypes = (tags['surveillance:type'] ?? '').split(';').map((s) => s.trim());
+    if (!surveillanceTypes.includes('ALPR')) continue;
 
     let lat = el.lat;
     let lon = el.lon;


### PR DESCRIPTION
The camera fetcher requires both `man_made=surveillance` and an exact `surveillance:type=ALPR`, which silently drops two classes of valid ALPRs:

- nodes tagged `surveillance:type=ALPR` but missing `man_made=surveillance` (~161 in the US)
- nodes using a multi-value tag such as `camera;ALPR` or `ALPR;camera` (~90)

`man_made=surveillance` is redundant when `surveillance:type=ALPR` is present, so this drops it and matches ALPR as one of the `;`-separated `surveillance:type` values. The change is applied in both places that enforced the old rule — the Overpass query and the `transformOverpassToGeoJSON` filter. The `(^|;)ALPR($|;)` token boundary avoids false matches like `ALPR150`.