### PR TITLE
Add a compass to reset the map north

### DIFF
--- a/src/components/map/MapLibreContainer.tsx
+++ b/src/components/map/MapLibreContainer.tsx
@@ -1369,7 +1369,7 @@ export const MapLibreView = forwardRef<MapLibreViewHandle, MapLibreViewProps>(
       attributionControl={false}
       // Removed reuseMaps to avoid stale reused instances
     >
-      <NavigationControl position="bottom-right" showCompass={false} />
+      <NavigationControl position="bottom-right" showCompass />
       <GeolocateControl position="bottom-right" />
       <AttributionCtl key={attribPosition} position={attribPosition} />
 

--- a/src/index.css
+++ b/src/index.css
@@ -409,10 +409,8 @@ input[type="range"]::-moz-range-thumb {
   left: 16px;
 }
 
-/* Theme (light/dark) pill — right column, above geolocate + zoom.
-   24px (ctrl offset) + 76px (zoom group) + 10px margin + 40px (geolocate) + 12px gap */
 .map-page .map-theme-control {
-  bottom: 162px;
+  bottom: 198px;
   right: 26px; /* 16px (ctrl container offset) + 10px (maplibregl-ctrl margin) */
 }
 
@@ -446,7 +444,8 @@ input[type="range"]::-moz-range-thumb {
   }
 
   /* Hide zoom +/- on touch layouts — pinch-to-zoom covers it */
-  .map-page .maplibregl-ctrl-group:has(.maplibregl-ctrl-zoom-in) {
+  .map-page .maplibregl-ctrl-zoom-in,
+  .map-page .maplibregl-ctrl-zoom-out {
     display: none;
   }
 
@@ -482,10 +481,8 @@ input[type="range"]::-moz-range-thumb {
     height: 38px;
   }
 
-  /* Theme pill floats above geolocate with a small gap.
-     Offset tracks --drawer-height: 12px gap + 40px geolocate + 8px gap. */
   .map-page .map-theme-control {
-    bottom: calc(var(--drawer-height, 80px) + 72px);
+    bottom: calc(var(--drawer-height, 80px) + 120px);
     right: 22px; /* 12px (ctrl container offset) + 10px (maplibregl-ctrl margin) */
   }
 


### PR DESCRIPTION
It's easy to accidentally rotate the map on mobile, and refreshing was the easiest way to get it pointing north again. The built-in compass was disabled, so this turns it on and keeps it visible on smaller screens too. Clicking it points the map north again without changing where you're looking.

I also moved the nearby controls up a little so nothing overlaps.

Checked with:

- `npm test`
- `npm run build`
- targeted ESLint check
- desktop and mobile browser checks

`npm run lint` still fails on a pre-existing `no-namespace` error in `worker/src/types.ts`; that file isn't touched by this PR, and the changed map file has no lint errors.
