### PR TITLE
Render tagged camera direction spans

### DIFF
--- a/src/components/map/layers/CameraMarkerLayers.tsx
+++ b/src/components/map/layers/CameraMarkerLayers.tsx
@@ -4,7 +4,7 @@ import type maplibregl from 'maplibre-gl';
 import { useMapStore, useAppModeStore } from '../../../store';
 import { CAMERA_POINT_FILL } from './cameraColors';
 import type { ALPRCamera } from '../../../types';
-import { createDirectionCone, parseDirections } from './cameraGeometry';
+import { cameraMarkerCones } from './cameraMarkerCones';
 
 // Convert cameras to GeoJSON - optimized with pre-allocated array
 function camerasToGeoJSON(cameras: ALPRCamera[]): GeoJSON.FeatureCollection {
@@ -191,18 +191,12 @@ export function CameraMarkerLayers({ cameras, visible }: CameraMarkerLayersProps
       console.log(`[CameraMarkerLayers] Cameras with direction: ${camerasWithDirection.length} / ${cameras.length}`);
     }
 
-    const features: GeoJSON.Feature[] = [];
+    const coneFeatures: Array<GeoJSON.Feature<GeoJSON.Polygon>> = [];
     for (const camera of camerasWithDirection) {
-      const bearings = parseDirections(camera.direction, camera.directions);
-      const ts = camera.osmTimestamp ? new Date(camera.osmTimestamp).getTime() : 0;
-      for (const bearing of bearings) {
-        const cone = createDirectionCone(camera.lon, camera.lat, bearing);
-        cone.properties = { ...cone.properties, ts };
-        features.push(cone);
-      }
+      coneFeatures.push(...cameraMarkerCones(camera));
     }
 
-    return { type: 'FeatureCollection', features };
+    return { type: 'FeatureCollection', features: coneFeatures };
   }, [cameras, showCameraLayer]);
 
   return (

--- a/src/components/map/layers/CameraTileLayers.tsx
+++ b/src/components/map/layers/CameraTileLayers.tsx
@@ -8,7 +8,7 @@ import {
   CAMERA_TILES_MAXZOOM,
   CAMERA_POINTS_MINZOOM,
 } from '../../../services/cameraTilesService';
-import { createDirectionCone, parseDirections } from './cameraGeometry';
+import { cameraTileCones } from './cameraTileCones';
 import { CAMERA_POINT_FILL } from './cameraColors';
 import { useAppModeStore } from '../../../store';
 
@@ -204,32 +204,28 @@ export function CameraTileLayers({
     }
     if (!map.getSource(sourceId)) return;
 
-    const rendered = map.querySourceFeatures(sourceId, {
+    const tileFeatures = map.querySourceFeatures(sourceId, {
       sourceLayer: CAMERA_TILES_SOURCE_LAYER,
       filter,
     });
 
     // Dedupe by osmId (present at z9+) — zero-buffer tiles shouldn't duplicate
     // features, but querySourceFeatures can still return one per tile+zoom copy
-    const seen = new Set<number>();
-    const features: GeoJSON.Feature[] = [];
-    for (const f of rendered) {
-      const props = f.properties;
-      if (!props || props.osmId == null || seen.has(props.osmId)) continue;
-      seen.add(props.osmId);
-      const bearings = parseDirections(
-        props.direction as number | undefined,
-        props.directions
-      );
-      if (bearings.length === 0) continue;
-      const [lon, lat] = (f.geometry as GeoJSON.Point).coordinates;
-      for (const bearing of bearings) {
-        features.push(createDirectionCone(lon, lat, bearing));
-        if (features.length >= CONE_FEATURE_CAP) break;
+    const seenOsmIds = new Set<number>();
+    const coneFeatures: Array<GeoJSON.Feature<GeoJSON.Polygon>> = [];
+    for (const tileFeature of tileFeatures) {
+      const properties = tileFeature.properties;
+      if (!properties || properties.osmId == null || seenOsmIds.has(properties.osmId)) continue;
+      seenOsmIds.add(properties.osmId);
+      const cones = cameraTileCones(tileFeature as GeoJSON.Feature<GeoJSON.Point>);
+      if (cones.length === 0) continue;
+      for (const cone of cones) {
+        coneFeatures.push(cone);
+        if (coneFeatures.length >= CONE_FEATURE_CAP) break;
       }
-      if (features.length >= CONE_FEATURE_CAP) break;
+      if (coneFeatures.length >= CONE_FEATURE_CAP) break;
     }
-    setConesData({ type: 'FeatureCollection', features });
+    setConesData({ type: 'FeatureCollection', features: coneFeatures });
   }, [mapInstance, visible, sourceId, filter]);
 
   // Rebuild cones when tiles finish loading or the camera stops moving

--- a/src/components/map/layers/cameraGeometry.test.ts
+++ b/src/components/map/layers/cameraGeometry.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { createDirectionCone, resolveDirectionViews } from './cameraGeometry';
+
+describe('resolveDirectionViews', () => {
+  it('uses an explicit span for a singular direction', () => {
+    expect(resolveDirectionViews(261.5, undefined, 45, undefined)).toEqual([
+      { bearing: 261.5, spreadDegrees: 45 },
+    ]);
+  });
+
+  it.each([
+    { direction: 90, span: 0, expectedSpread: 50 },
+    { direction: 180, span: 360, expectedSpread: 360 },
+  ])(
+    'resolves singular span boundary $span to spread $expectedSpread',
+    ({ direction, span, expectedSpread }) => {
+      expect(resolveDirectionViews(direction, undefined, span, undefined)).toEqual([
+        { bearing: direction, spreadDegrees: expectedSpread },
+      ]);
+    },
+  );
+
+  it('drops non-finite singular bearings before polygon generation', () => {
+    expect(resolveDirectionViews(NaN, undefined, 45, undefined)).toEqual([]);
+    expect(resolveDirectionViews(Infinity, undefined, 45, undefined)).toEqual([]);
+    expect(resolveDirectionViews(-Infinity, undefined, 45, undefined)).toEqual([]);
+  });
+
+  it('aligns plural direction spans with their directions', () => {
+    expect(
+      resolveDirectionViews(90, [90, 255, 0], undefined, [null, 10, null]),
+    ).toEqual([
+      { bearing: 90, spreadDegrees: 50 },
+      { bearing: 255, spreadDegrees: 10 },
+      { bearing: 0, spreadDegrees: 50 },
+    ]);
+  });
+
+  it('decodes JSON-stringified aligned plural directions and spans', () => {
+    expect(
+      resolveDirectionViews(90, '[90,255,0]', undefined, '[null,10,null]'),
+    ).toEqual([
+      { bearing: 90, spreadDegrees: 50 },
+      { bearing: 255, spreadDegrees: 10 },
+      { bearing: 0, spreadDegrees: 50 },
+    ]);
+  });
+
+  it('drops invalid native plural bearings without shifting aligned spans', () => {
+    expect(
+      resolveDirectionViews(0, [90, null, 'bad', Infinity, 255], undefined, [10, 20, 30, 40, 50]),
+    ).toEqual([
+      { bearing: 90, spreadDegrees: 10 },
+      { bearing: 255, spreadDegrees: 50 },
+    ]);
+  });
+
+  it('drops invalid JSON plural bearings without shifting aligned spans', () => {
+    expect(
+      resolveDirectionViews(0, '[90,null,"bad",255]', undefined, '[10,20,30,50]'),
+    ).toEqual([
+      { bearing: 90, spreadDegrees: 10 },
+      { bearing: 255, spreadDegrees: 50 },
+    ]);
+  });
+
+  it('falls back per index when an aligned plural span is invalid', () => {
+    const views = resolveDirectionViews(
+      0,
+      [0, 45, 90, 135, 180, 225, 270, 315],
+      undefined,
+      [null, 0, -1, NaN, Infinity, 361, '10', 10],
+    );
+
+    expect(views.map(({ spreadDegrees }) => spreadDegrees)).toEqual([
+      50, 50, 50, 50, 50, 50, 50, 10,
+    ]);
+  });
+
+  it('supports short plural spans and falls back from malformed plural JSON', () => {
+    expect(resolveDirectionViews(90, [90, 255, 0], 50, [10])).toEqual([
+      { bearing: 90, spreadDegrees: 10 },
+      { bearing: 255, spreadDegrees: 50 },
+      { bearing: 0, spreadDegrees: 50 },
+    ]);
+
+    expect(resolveDirectionViews(90, '[90,255,0', 50, '[10')).toEqual([
+      { bearing: 90, spreadDegrees: 50 },
+    ]);
+  });
+});
+
+describe('createDirectionCone', () => {
+  it('creates a closed finite full-circle polygon spanning all four quadrants', () => {
+    const cone = createDirectionCone(0, 0, 180, 100, 360);
+    const coordinates = cone.geometry.coordinates[0];
+    const radialArcSamples = coordinates.slice(1, -1);
+
+    expect(coordinates.every((point) => point.every(Number.isFinite))).toBe(true);
+    expect(coordinates[coordinates.length - 1]).toEqual(coordinates[0]);
+    expect([
+      radialArcSamples.some(([x, y]) => x > 0 && y > 0),
+      radialArcSamples.some(([x, y]) => x < 0 && y > 0),
+      radialArcSamples.some(([x, y]) => x < 0 && y < 0),
+      radialArcSamples.some(([x, y]) => x > 0 && y < 0),
+    ]).toEqual([true, true, true, true]);
+  });
+});

--- a/src/components/map/layers/cameraGeometry.ts
+++ b/src/components/map/layers/cameraGeometry.ts
@@ -1,44 +1,42 @@
 import { DIRECTIONAL_ZONE, CAMERA_DETECTION, ZONE_SAFETY_MULTIPLIERS } from '../../../services/routingConfig';
 
-// Helper to create a direction cone polygon from a point and direction
-// Uses the same parameters as the routing algorithm for consistency
+// Helper to create a direction cone polygon from a point and direction.
+// Defaults come from routing config; explicit spans can be visualization metadata.
 export function createDirectionCone(
   lon: number,
   lat: number,
   direction: number,
-  // Use routing config values so visualization matches what routing avoids
   lengthMeters: number = CAMERA_DETECTION.routeBufferMeters * ZONE_SAFETY_MULTIPLIERS.block * 0.75,
   spreadDegrees: number = DIRECTIONAL_ZONE.cameraFovDegrees
 ): GeoJSON.Feature<GeoJSON.Polygon> {
-  const earthRadius = 6371000; // meters
+  const earthRadiusMeters = 6371000;
   const latRad = (lat * Math.PI) / 180;
 
   // Convert meters to degrees (approximate)
-  const lengthDeg = (lengthMeters / earthRadius) * (180 / Math.PI);
+  const lengthDegrees = (lengthMeters / earthRadiusMeters) * (180 / Math.PI);
+  const pointAtBearing = (bearingDegrees: number): [number, number] => {
+    const angle = (bearingDegrees * Math.PI) / 180;
+    return [
+      lon + lengthDegrees * Math.sin(angle) / Math.cos(latRad),
+      lat + lengthDegrees * Math.cos(angle),
+    ];
+  };
 
   // Calculate the three points of the cone
   const points: [number, number][] = [[lon, lat]]; // Start at camera
 
   // Left edge of cone
-  const leftAngle = ((direction - spreadDegrees / 2) * Math.PI) / 180;
-  const leftLon = lon + lengthDeg * Math.sin(leftAngle) / Math.cos(latRad);
-  const leftLat = lat + lengthDeg * Math.cos(leftAngle);
-  points.push([leftLon, leftLat]);
+  points.push(pointAtBearing(direction - spreadDegrees / 2));
 
   // Create arc for the front of the cone
-  const steps = 8;
-  for (let i = 1; i < steps; i++) {
-    const angle = ((direction - spreadDegrees / 2 + (spreadDegrees * i) / steps) * Math.PI) / 180;
-    const arcLon = lon + lengthDeg * Math.sin(angle) / Math.cos(latRad);
-    const arcLat = lat + lengthDeg * Math.cos(angle);
-    points.push([arcLon, arcLat]);
+  const arcSteps = 8;
+  for (let step = 1; step < arcSteps; step++) {
+    const bearing = direction - spreadDegrees / 2 + (spreadDegrees * step) / arcSteps;
+    points.push(pointAtBearing(bearing));
   }
 
   // Right edge of cone
-  const rightAngle = ((direction + spreadDegrees / 2) * Math.PI) / 180;
-  const rightLon = lon + lengthDeg * Math.sin(rightAngle) / Math.cos(latRad);
-  const rightLat = lat + lengthDeg * Math.cos(rightAngle);
-  points.push([rightLon, rightLat]);
+  points.push(pointAtBearing(direction + spreadDegrees / 2));
 
   // Close the polygon
   points.push([lon, lat]);
@@ -53,6 +51,55 @@ export function createDirectionCone(
   };
 }
 
+export interface DirectionView {
+  bearing: number;
+  spreadDegrees: number;
+}
+
+function resolveSpreadDegrees(spread: unknown): number {
+  return typeof spread === 'number' && Number.isFinite(spread) && spread > 0 && spread <= 360
+    ? spread
+    : DIRECTIONAL_ZONE.cameraFovDegrees;
+}
+
+function parseArrayAttribute(value: unknown): unknown[] | undefined {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveDirectionViews(
+  direction: number | null | undefined,
+  directions: unknown,
+  directionSpan: number | null | undefined,
+  directionSpans: unknown
+): DirectionView[] {
+  const parsedDirections = parseArrayAttribute(directions);
+  if (parsedDirections && parsedDirections.length > 1) {
+    const alignedSpans = parseArrayAttribute(directionSpans) ?? [];
+    return parsedDirections.flatMap((bearing, index) =>
+      typeof bearing === 'number' && Number.isFinite(bearing)
+        ? [{ bearing, spreadDegrees: resolveSpreadDegrees(alignedSpans[index]) }]
+        : []
+    );
+  }
+
+  if (typeof direction !== 'number' || !Number.isFinite(direction)) return [];
+
+  return [
+    {
+      bearing: direction,
+      spreadDegrees: resolveSpreadDegrees(directionSpan),
+    },
+  ];
+}
+
 /**
  * Normalize a camera's bearing(s). `directions` may be a real array (from the
  * GeoJSON dataset) or a JSON-encoded string like "[90,270]" (from vector
@@ -62,19 +109,13 @@ export function parseDirections(
   direction: number | null | undefined,
   directions: unknown
 ): number[] {
-  if (Array.isArray(directions) && directions.length > 1) {
-    return directions.filter((d): d is number => Number.isFinite(d));
+  const parsedDirections = parseArrayAttribute(directions);
+  if (Array.isArray(directions) && parsedDirections && parsedDirections.length > 1) {
+    return parsedDirections.filter((value): value is number => Number.isFinite(value));
   }
-  if (typeof directions === 'string' && directions.length > 0) {
-    try {
-      const parsed = JSON.parse(directions);
-      if (Array.isArray(parsed)) {
-        const nums = parsed.map(Number).filter(Number.isFinite);
-        if (nums.length > 1) return nums;
-      }
-    } catch {
-      // fall through to single direction
-    }
+  if (typeof directions === 'string' && parsedDirections) {
+    const numericDirections = parsedDirections.map(Number).filter(Number.isFinite);
+    if (numericDirections.length > 1) return numericDirections;
   }
   return direction !== null && direction !== undefined && Number.isFinite(direction)
     ? [direction]

--- a/src/components/map/layers/cameraMarkerCones.test.ts
+++ b/src/components/map/layers/cameraMarkerCones.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { ALPRCamera } from '../../../types';
+import { createDirectionCone } from './cameraGeometry';
+import { cameraMarkerCones } from './cameraMarkerCones';
+
+const timestamp = '2024-05-20T12:34:56.000Z';
+const expectedTimestamp = new Date(timestamp).getTime();
+
+function camera(overrides: Partial<ALPRCamera>): ALPRCamera {
+  return {
+    osmId: 123,
+    osmType: 'node',
+    lat: 33.7,
+    lon: -84.4,
+    osmTimestamp: timestamp,
+    ...overrides,
+  };
+}
+
+describe('cameraMarkerCones', () => {
+  it('creates a singular camera cone using its direction span and timestamp', () => {
+    const source = camera({ direction: 90, directionSpan: 10 });
+
+    const cones = cameraMarkerCones(source);
+
+    expect(cones).toHaveLength(1);
+    expect(cones[0].geometry.coordinates).toEqual(
+      createDirectionCone(source.lon, source.lat, 90, undefined, 10).geometry.coordinates,
+    );
+    expect(cones[0].properties?.ts).toBe(expectedTimestamp);
+  });
+
+  it('creates native plural direction cones using aligned spans and fallback spreads', () => {
+    const source = camera({
+      direction: 90,
+      directions: [90, 255, 0],
+      directionSpans: [null, 10, null],
+    });
+
+    const cones = cameraMarkerCones(source);
+
+    expect(cones).toHaveLength(3);
+    expect(cones.map((cone) => cone.geometry.coordinates)).toEqual([
+      createDirectionCone(source.lon, source.lat, 90, undefined, 50).geometry.coordinates,
+      createDirectionCone(source.lon, source.lat, 255, undefined, 10).geometry.coordinates,
+      createDirectionCone(source.lon, source.lat, 0, undefined, 50).geometry.coordinates,
+    ]);
+    expect(cones.map((cone) => cone.properties?.ts)).toEqual([
+      expectedTimestamp,
+      expectedTimestamp,
+      expectedTimestamp,
+    ]);
+  });
+});

--- a/src/components/map/layers/cameraMarkerCones.ts
+++ b/src/components/map/layers/cameraMarkerCones.ts
@@ -1,0 +1,28 @@
+import type { ALPRCamera } from '../../../types';
+import { createDirectionCone, resolveDirectionViews } from './cameraGeometry';
+
+export function cameraMarkerCones(
+  camera: ALPRCamera,
+): GeoJSON.Feature<GeoJSON.Polygon>[] {
+  const timestampMs = camera.osmTimestamp
+    ? new Date(camera.osmTimestamp).getTime()
+    : 0;
+  const directionViews = resolveDirectionViews(
+    camera.direction,
+    camera.directions,
+    camera.directionSpan,
+    camera.directionSpans,
+  );
+
+  return directionViews.map(({ bearing, spreadDegrees }) => {
+    const cone = createDirectionCone(
+      camera.lon,
+      camera.lat,
+      bearing,
+      undefined,
+      spreadDegrees,
+    );
+    cone.properties = { ...cone.properties, ts: timestampMs };
+    return cone;
+  });
+}

--- a/src/components/map/layers/cameraTileCones.test.ts
+++ b/src/components/map/layers/cameraTileCones.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { createDirectionCone } from './cameraGeometry';
+import { cameraTileCones } from './cameraTileCones';
+
+const coordinates = [-73.9857, 40.7484] as [number, number];
+
+function tileFeature(
+  properties: GeoJSON.GeoJsonProperties,
+): GeoJSON.Feature<GeoJSON.Point> {
+  return {
+    type: 'Feature',
+    properties,
+    geometry: {
+      type: 'Point',
+      coordinates,
+    },
+  };
+}
+
+describe('cameraTileCones', () => {
+  it('creates a cone using singular tile direction and directionSpan properties', () => {
+    const cones = cameraTileCones(
+      tileFeature({ direction: 90, directionSpan: 10 }),
+    );
+
+    expect(cones.map((cone) => cone.geometry.coordinates)).toEqual([
+      createDirectionCone(coordinates[0], coordinates[1], 90, undefined, 10)
+        .geometry.coordinates,
+    ]);
+  });
+
+  it('creates aligned cones from PMTiles JSON-stringified directions and spans', () => {
+    const cones = cameraTileCones(
+      tileFeature({
+        directions: '[90,255,0]',
+        directionSpans: '[null,10,null]',
+      }),
+    );
+
+    expect(cones.map((cone) => cone.geometry.coordinates)).toEqual(
+      [
+        createDirectionCone(coordinates[0], coordinates[1], 90, undefined, 50),
+        createDirectionCone(coordinates[0], coordinates[1], 255, undefined, 10),
+        createDirectionCone(coordinates[0], coordinates[1], 0, undefined, 50),
+      ].map((cone) => cone.geometry.coordinates),
+    );
+  });
+});

--- a/src/components/map/layers/cameraTileCones.ts
+++ b/src/components/map/layers/cameraTileCones.ts
@@ -1,0 +1,18 @@
+import { createDirectionCone, resolveDirectionViews } from './cameraGeometry';
+
+export function cameraTileCones(
+  feature: GeoJSON.Feature<GeoJSON.Point>,
+): GeoJSON.Feature<GeoJSON.Polygon>[] {
+  const properties = feature.properties ?? {};
+  const [longitude, latitude] = feature.geometry.coordinates;
+  const directionViews = resolveDirectionViews(
+    properties.direction,
+    properties.directions,
+    properties.directionSpan,
+    properties.directionSpans,
+  );
+
+  return directionViews.map(({ bearing, spreadDegrees }) =>
+    createDirectionCone(longitude, latitude, bearing, undefined, spreadDegrees),
+  );
+}

--- a/src/services/cameraDataService.test.ts
+++ b/src/services/cameraDataService.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { readBodyWithProgress } from './cameraDataService';
+import {
+  clearCameraCache,
+  loadBundledCameras,
+  readBodyWithProgress,
+} from './cameraDataService';
 
 function chunkStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -11,6 +15,23 @@ function chunkStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
 }
 
 const enc = new TextEncoder();
+
+describe('COUNTRIES', () => {
+  it('uses the development US camera-data URL override', async () => {
+    const dataUrl = 'https://fixture.test/cameras.geojson';
+    vi.stubEnv('VITE_CAMERA_DATA_URL_US', dataUrl);
+    vi.resetModules();
+
+    try {
+      const { COUNTRIES } = await import('./cameraDataService');
+
+      expect(COUNTRIES.us.dataUrl).toBe(dataUrl);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+});
 
 describe('readBodyWithProgress', () => {
   it('reports determinate percent when Content-Length is present and no Content-Encoding', async () => {
@@ -55,5 +76,76 @@ describe('readBodyWithProgress', () => {
   it('works without a callback', async () => {
     const response = new Response(chunkStream([enc.encode('{"ok":true}')]));
     await expect(readBodyWithProgress(response)).resolves.toBe('{"ok":true}');
+  });
+});
+
+describe('loadBundledCameras', () => {
+  it('hydrates direction spans from FeatureCollection properties', async () => {
+    const featureCollection = {
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [-84.4, 33.7] },
+        properties: {
+          osmId: 123,
+          osmType: 'node',
+          direction: 90,
+          directions: [90, 255, 0],
+          directionSpan: 10,
+          directionSpans: [null, 10, null],
+        },
+      }],
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(featureCollection), { status: 200 })
+    ));
+
+    clearCameraCache();
+
+    try {
+      const [camera] = await loadBundledCameras();
+
+      expect(camera.direction).toBe(90);
+      expect(camera.directions).toEqual([90, 255, 0]);
+      expect(camera).toMatchObject({
+        directionSpan: 10,
+        directionSpans: [null, 10, null],
+      });
+    } finally {
+      clearCameraCache();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('hydrates direction spans from legacy flat-array records', async () => {
+    const cameras = [{
+      osmId: 123,
+      osmType: 'node',
+      lat: 33.7,
+      lon: -84.4,
+      direction: 90,
+      directions: [90, 255, 0],
+      directionSpan: 10,
+      directionSpans: [null, 10, null],
+    }];
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(cameras), { status: 200 })
+    ));
+
+    clearCameraCache();
+
+    try {
+      const [camera] = await loadBundledCameras();
+
+      expect(camera.direction).toBe(90);
+      expect(camera.directions).toEqual([90, 255, 0]);
+      expect(camera).toMatchObject({
+        directionSpan: 10,
+        directionSpans: [null, 10, null],
+      });
+    } finally {
+      clearCameraCache();
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/src/services/cameraDataService.ts
+++ b/src/services/cameraDataService.ts
@@ -80,7 +80,7 @@ export const COUNTRIES: Record<CameraCountry, CountryConfig> = {
     id: 'us',
     label: 'United States',
     flag: '🇺🇸',
-    dataUrl: 'https://data.dontgetflocked.com/cameras.geojson.gz',
+    dataUrl: import.meta.env.VITE_CAMERA_DATA_URL_US || 'https://data.dontgetflocked.com/cameras.geojson.gz',
     center: [39.8283, -98.5795],
     zoom: 4,
   },
@@ -128,6 +128,46 @@ const loadStates: Record<CameraCountry, CountryLoadState> = {
 
 const MAX_LOAD_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 1000;
+
+type CameraProperties = Partial<ALPRCamera> & Pick<ALPRCamera, 'osmId'>;
+type LegacyCameraRecord = CameraProperties & Pick<ALPRCamera, 'lat' | 'lon'>;
+
+interface CameraPointFeature {
+  geometry: { coordinates: [number, number] };
+  properties: CameraProperties;
+}
+
+function hydrateCamera(properties: CameraProperties, lat: number, lon: number): ALPRCamera {
+  return {
+    osmId: properties.osmId,
+    osmType: properties.osmType || 'node',
+    lat,
+    lon,
+    operator: properties.operator,
+    brand: properties.brand,
+    direction: properties.direction,
+    directions: properties.directions,
+    directionSpan: properties.directionSpan,
+    directionSpans: properties.directionSpans,
+    directionCardinal: properties.directionCardinal,
+    surveillanceZone: properties.surveillanceZone,
+    mountType: properties.mountType,
+    ref: properties.ref,
+    startDate: properties.startDate,
+    osmTimestamp: properties.osmTimestamp,
+    osmVersion: properties.osmVersion,
+    wikimediaCommons: properties.wikimediaCommons,
+  };
+}
+
+function hydrateFeatureCollectionCamera(feature: CameraPointFeature): ALPRCamera {
+  const [lon, lat] = feature.geometry.coordinates;
+  return hydrateCamera(feature.properties, lat, lon);
+}
+
+function hydrateLegacyCamera(camera: LegacyCameraRecord): ALPRCamera {
+  return hydrateCamera(camera, camera.lat, camera.lon);
+}
 
 /**
  * Load camera data for a country from the data Worker
@@ -199,26 +239,7 @@ export async function loadBundledCameras(
           }
           cameras = new Array(data.features.length);
           for (let i = 0; i < data.features.length; i++) {
-            const f = data.features[i];
-            const p = f.properties;
-            cameras[i] = {
-              osmId: p.osmId,
-              osmType: p.osmType || 'node',
-              lat: f.geometry.coordinates[1],
-              lon: f.geometry.coordinates[0],
-              operator: p.operator,
-              brand: p.brand,
-              direction: p.direction,
-              directions: p.directions,
-              directionCardinal: p.directionCardinal,
-              surveillanceZone: p.surveillanceZone,
-              mountType: p.mountType,
-              ref: p.ref,
-              startDate: p.startDate,
-              osmTimestamp: p.osmTimestamp,
-              osmVersion: p.osmVersion,
-              wikimediaCommons: p.wikimediaCommons,
-            };
+            cameras[i] = hydrateFeatureCollectionCamera(data.features[i]);
           }
         } else if (Array.isArray(data)) {
           // Legacy flat array format (backwards compatibility during migration)
@@ -227,25 +248,7 @@ export async function loadBundledCameras(
           }
           cameras = new Array(data.length);
           for (let i = 0; i < data.length; i++) {
-            const cam = data[i];
-            cameras[i] = {
-              osmId: cam.osmId,
-              osmType: cam.osmType || 'node',
-              lat: cam.lat,
-              lon: cam.lon,
-              operator: cam.operator,
-              brand: cam.brand,
-              direction: cam.direction,
-              directions: cam.directions,
-              directionCardinal: cam.directionCardinal,
-              surveillanceZone: cam.surveillanceZone,
-              mountType: cam.mountType,
-              ref: cam.ref,
-              startDate: cam.startDate,
-              osmTimestamp: cam.osmTimestamp,
-              osmVersion: cam.osmVersion,
-              wikimediaCommons: cam.wikimediaCommons,
-            };
+            cameras[i] = hydrateLegacyCamera(data[i]);
           }
         } else {
           throw new Error('Invalid camera data format');

--- a/src/services/cameraTilesService.test.ts
+++ b/src/services/cameraTilesService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { archiveKey } from './cameraTilesService';
 
 describe('archiveKey', () => {
@@ -15,5 +15,37 @@ describe('archiveKey', () => {
   it('returns null for non-camera / basemap urls', () => {
     expect(archiveKey('https://tiles.dontgetflocked.com/planet.json')).toBeNull();
     expect(archiveKey('pmtiles://example.com/something-else.pmtiles')).toBeNull();
+  });
+});
+
+describe('development camera tiles host override', () => {
+  it('uses VITE_CAMERA_TILES_HOST for every tile artifact URL', async () => {
+    vi.stubEnv('VITE_CAMERA_TILES_HOST', 'http://127.0.0.1:4174');
+    vi.resetModules();
+
+    try {
+      const {
+        cameraTilesUrl,
+        cameraFilterTilesUrl,
+        cameraFilterTileJsonUrl,
+        cameraManifestUrl,
+      } = await import('./cameraTilesService');
+
+      expect(cameraTilesUrl('us')).toBe(
+        'pmtiles://http://127.0.0.1:4174/cameras-us-hourly.pmtiles',
+      );
+      expect(cameraFilterTilesUrl('us')).toBe(
+        'pmtiles://http://127.0.0.1:4174/cameras-us-hourly-filter.pmtiles',
+      );
+      expect(cameraFilterTileJsonUrl('us')).toBe(
+        'http://127.0.0.1:4174/cameras-us-hourly-filter.json',
+      );
+      expect(cameraManifestUrl('us')).toBe(
+        'http://127.0.0.1:4174/cameras-us-hourly-manifest.json',
+      );
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
   });
 });

--- a/src/services/cameraTilesService.ts
+++ b/src/services/cameraTilesService.ts
@@ -12,7 +12,8 @@ import { Protocol } from 'pmtiles';
  * - zero tile buffer — no duplicated points along tile seams, so
  *   translucent circle layers never double-blend
  */
-export const CAMERA_TILES_HOST = 'https://tiles.dontgetflocked.com';
+export const CAMERA_TILES_HOST =
+  import.meta.env.VITE_CAMERA_TILES_HOST || 'https://tiles.dontgetflocked.com';
 
 /** Countries with hourly tile archives (both main + filter companions). */
 export type CameraTileCountry = 'us' | 'ca';

--- a/src/types/camera.ts
+++ b/src/types/camera.ts
@@ -8,6 +8,8 @@ export interface ALPRCamera {
   model?: string;
   direction?: number;
   directions?: number[];
+  directionSpan?: number;
+  directionSpans?: Array<number | null>;
   directionCardinal?: string;
   surveillanceZone?: 'traffic' | 'town' | 'parking' | 'other';
   mountType?: 'pole' | 'wall' | 'street_light' | 'other';

--- a/tests/fixtures/issue145-cameras.geojson
+++ b/tests/fixtures/issue145-cameras.geojson
@@ -1,0 +1,38 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [0.01, 0.01] },
+      "properties": {
+        "osmId": 145001,
+        "osmType": "node",
+        "brand": "Flock Safety",
+        "direction": 261.5,
+        "directionSpan": 45
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [0.011, 0.01] },
+      "properties": {
+        "osmId": 145002,
+        "osmType": "node",
+        "brand": "Flock Safety",
+        "direction": 90,
+        "directions": [90, 255, 0],
+        "directionSpans": [null, 10, null]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [0.012, 0.01] },
+      "properties": {
+        "osmId": 145003,
+        "osmType": "node",
+        "brand": "Flock Safety",
+        "direction": 180
+      }
+    }
+  ]
+}

--- a/worker/src/fetchers/cameras.ts
+++ b/worker/src/fetchers/cameras.ts
@@ -188,27 +188,35 @@ function resolveSimple(token: string): number | null {
   if (upper in SPELLED_CARDINALS) return SPELLED_CARDINALS[upper];
   if (upper in BOUND_DIRECTIONS) return BOUND_DIRECTIONS[upper];
   const num = Number(upper);  // Number() rejects "338-23" unlike parseFloat
-  return isNaN(num) ? null : num;
+  return Number.isFinite(num) ? num : null;
 }
 
-/** Compute the midpoint bearing of a clockwise sector from startDeg to endDeg (raw values, not pre-normalized). */
-function rangeMidpoint(startDeg: number, endDeg: number): number {
+/** Compute the clockwise span from startDeg to endDeg (raw values, not pre-normalized). */
+function rangeSpan(startDeg: number, endDeg: number): number {
   const rawArc = endDeg - startDeg;
-  const arc = ((rawArc % 360) + 360) % 360;
+  const normalizedArc = normalizeDegrees(rawArc);
   // Full circle: raw values differ but normalized arc is 0 (e.g. 0→360)
-  if (arc === 0 && rawArc !== 0) return normalizeDegrees(startDeg + 180);
-  if (arc === 0) return normalizeDegrees(startDeg);
-  return normalizeDegrees(startDeg + arc / 2);
+  return normalizedArc === 0 && rawArc !== 0 ? 360 : normalizedArc;
 }
 
-/** Parse a single direction token which may be a cardinal, numeric, bound, spelled-out, or range (e.g. "338-23"). */
-function parseSingleToken(token: string): number | null {
+/** Compute the midpoint bearing of a clockwise sector from startDeg to endDeg. */
+function rangeMidpoint(startDeg: number, endDeg: number): number {
+  return normalizeDegrees(startDeg + rangeSpan(startDeg, endDeg) / 2);
+}
+
+interface ParsedDirectionToken {
+  bearing: number;
+  span?: number;
+}
+
+/** Parse one token while retaining range metadata needed during publication. */
+function parseDetailedToken(token: string): ParsedDirectionToken | null {
   const trimmed = token.trim();
   if (!trimmed) return null;
 
   // Try simple resolve first (cardinal, spelled-out, bound, numeric)
   const simple = resolveSimple(trimmed);
-  if (simple !== null) return normalizeDegrees(simple);
+  if (simple !== null) return { bearing: normalizeDegrees(simple) };
 
   // Range notation: "338-23", "WSW-ESE" — find dash that isn't a leading negative
   const dashIdx = trimmed.indexOf('-', 1);
@@ -216,23 +224,32 @@ function parseSingleToken(token: string): number | null {
     const left = resolveSimple(trimmed.slice(0, dashIdx));
     const right = resolveSimple(trimmed.slice(dashIdx + 1));
     if (left !== null && right !== null) {
-      return rangeMidpoint(left, right);
+      const span = rangeSpan(left, right);
+      const bearing = rangeMidpoint(left, right);
+      if (!Number.isFinite(span) || !Number.isFinite(bearing)) return null;
+      return {
+        bearing,
+        span,
+      };
     }
   }
 
   return null;
 }
 
-/** Parse a direction tag into all resolved bearings (handles semicolons and commas). */
-export function parseDirections(value: string | undefined): number[] {
+function parseDetailedDirections(value: string | undefined): ParsedDirectionToken[] {
   if (!value) return [];
-  const tokens = value.split(/[;,]/).map((t) => t.trim()).filter(Boolean);
-  const results: number[] = [];
-  for (const token of tokens) {
-    const deg = parseSingleToken(token);
-    if (deg !== null) results.push(deg);
+  const results: ParsedDirectionToken[] = [];
+  for (const token of value.split(/[;,]/)) {
+    const parsed = parseDetailedToken(token);
+    if (parsed !== null) results.push(parsed);
   }
   return results;
+}
+
+/** Parse a direction tag into all resolved bearings (handles semicolons and commas). */
+export function parseDirections(value: string | undefined): number[] {
+  return parseDetailedDirections(value).map(({ bearing }) => bearing);
 }
 
 /** Parse a direction tag into a single bearing (first resolved value). Backward-compatible. */
@@ -284,8 +301,15 @@ export function addElementsToFeatures(
     if (lat === undefined || lon === undefined) continue;
 
     const directionTag = tags['direction'] || tags['camera:direction'];
-    const directions = parseDirections(directionTag);
-    const direction = directions.length > 0 ? directions[0] : null;
+    const parsedDirections = parseDetailedDirections(directionTag);
+    const firstDirection = parsedDirections[0];
+    const directions = parsedDirections.map(({ bearing }) => bearing);
+    const direction = firstDirection?.bearing ?? null;
+    const directionSpan = firstDirection?.span;
+    const directionSpans = parsedDirections.length > 1
+      && parsedDirections.some(({ span }) => span !== undefined)
+      ? parsedDirections.map(({ span }) => span ?? null)
+      : undefined;
     // directionCardinal stores the original cardinal string when the (first) token is a compass point
     const firstToken = directionTag?.split(/[;,]/)[0]?.trim();
     const isCardinal = firstToken ? firstToken.toUpperCase() in CARDINALS : false;
@@ -300,7 +324,9 @@ export function addElementsToFeatures(
       properties.brand = tags['brand'] || tags['manufacturer'];
     }
     if (direction !== null) properties.direction = direction;
+    if (directionSpan !== undefined) properties.directionSpan = directionSpan;
     if (directions.length > 1) properties.directions = directions;
+    if (directionSpans !== undefined) properties.directionSpans = directionSpans;
     if (isCardinal) properties.directionCardinal = firstToken;
     if (tags['surveillance:zone']) properties.surveillanceZone = tags['surveillance:zone'];
     if (tags['camera:mount']) properties.mountType = tags['camera:mount'];

--- a/worker/tests/fetchers/cameras.test.ts
+++ b/worker/tests/fetchers/cameras.test.ts
@@ -312,6 +312,25 @@ describe('transformOverpassToGeoJSON', () => {
     expect(fc.features[1].properties.directions).toBeUndefined();
   });
 
+  it('does not invent span metadata for plural non-range directions', () => {
+    const response: OverpassResponse = {
+      version: 0.6,
+      generator: 'Overpass API',
+      elements: [
+        {
+          type: 'node', id: 1, lat: 38.0, lon: -77.0,
+          tags: { 'man_made': 'surveillance', 'surveillance:type': 'ALPR', 'direction': '90;270' },
+        },
+      ],
+    };
+
+    const feature = transformOverpassToGeoJSON(response).features[0];
+    expect(feature.properties.direction).toBe(90);
+    expect(feature.properties.directions).toEqual([90, 270]);
+    expect(feature.properties.directionSpan).toBeUndefined();
+    expect(feature.properties.directionSpans).toBeUndefined();
+  });
+
   it('handles range notation in transform', () => {
     const response: OverpassResponse = {
       version: 0.6,
@@ -326,6 +345,106 @@ describe('transformOverpassToGeoJSON', () => {
 
     const fc = transformOverpassToGeoJSON(response);
     expect(fc.features[0].properties.direction).toBeCloseTo(0.5, 1);
+  });
+
+  it.each([
+    ['57-117', 87, 60],
+    ['338-23', 0.5, 45],
+    ['90-90', 90, 0],
+    ['0-360', 180, 360],
+  ])('publishes boundary range %s as midpoint %s and span %s', (range, midpoint, span) => {
+    const response: OverpassResponse = {
+      version: 0.6,
+      generator: 'Overpass API',
+      elements: [
+        {
+          type: 'node', id: 1, lat: 38.0, lon: -77.0,
+          tags: { 'man_made': 'surveillance', 'surveillance:type': 'ALPR', 'direction': range },
+        },
+      ],
+    };
+
+    const feature = transformOverpassToGeoJSON(response).features[0];
+    expect(feature.properties.direction).toBeCloseTo(midpoint, 5);
+    expect(feature.properties.directionSpan).toBe(span);
+  });
+
+  it('preserves the midpoint and span of a direction range', () => {
+    const response: OverpassResponse = {
+      version: 0.6,
+      generator: 'Overpass API',
+      elements: [
+        {
+          type: 'node', id: 1, lat: 38.0, lon: -77.0,
+          tags: { 'man_made': 'surveillance', 'surveillance:type': 'ALPR', 'direction': '239-284' },
+        },
+      ],
+    };
+
+    const fc = transformOverpassToGeoJSON(response);
+    expect(fc.features[0].properties.direction).toBeCloseTo(261.5, 1);
+    expect(fc.features[0].properties.directionSpan).toBe(45);
+  });
+
+  it('publishes aligned spans for plural direction tokens', () => {
+    const response: OverpassResponse = {
+      version: 0.6,
+      generator: 'Overpass API',
+      elements: [
+        {
+          type: 'node', id: 1, lat: 38.0, lon: -77.0,
+          tags: { 'man_made': 'surveillance', 'surveillance:type': 'ALPR', 'direction': '90;250-260;N' },
+        },
+      ],
+    };
+
+    const fc = transformOverpassToGeoJSON(response);
+    expect(fc.features[0].properties.direction).toBe(90);
+    expect(fc.features[0].properties.directions).toEqual([90, 255, 0]);
+    expect(fc.features[0].properties.directionSpan).toBeUndefined();
+    expect(fc.features[0].properties.directionSpans).toEqual([null, 10, null]);
+  });
+
+  it('uses the first retained token for singular range metadata', () => {
+    const response: OverpassResponse = {
+      version: 0.6,
+      generator: 'Overpass API',
+      elements: [
+        {
+          type: 'node', id: 1, lat: 38.0, lon: -77.0,
+          tags: { 'man_made': 'surveillance', 'surveillance:type': 'ALPR', 'direction': 'bad;250-260;N' },
+        },
+      ],
+    };
+
+    const fc = transformOverpassToGeoJSON(response);
+    expect(fc.features[0].properties.direction).toBe(255);
+    expect(fc.features[0].properties.directionSpan).toBe(10);
+    expect(fc.features[0].properties.directions).toEqual([255, 0]);
+    expect(fc.features[0].properties.directionSpans).toEqual([10, null]);
+  });
+
+  it.each([
+    '1e309;250-260',
+    '0-1e309;250-260',
+    '-1e308-1e308;250-260',
+  ])('atomically rejects non-finite direction token in %s', (direction) => {
+    const response: OverpassResponse = {
+      version: 0.6,
+      generator: 'Overpass API',
+      elements: [
+        {
+          type: 'node', id: 1, lat: 38.0, lon: -77.0,
+          tags: { 'man_made': 'surveillance', 'surveillance:type': 'ALPR', direction },
+        },
+      ],
+    };
+
+    const feature = transformOverpassToGeoJSON(response).features[0];
+    expect(feature.properties.direction).toBe(255);
+    expect(feature.properties.directionSpan).toBe(10);
+    expect(feature.properties.directions).toBeUndefined();
+    expect(feature.properties.directionSpans).toBeUndefined();
   });
 
   it('sets directionCardinal from first token of multi-value cardinal tag', () => {


### PR DESCRIPTION
## Summary

Consumes explicit camera direction spans across the Worker, hourly PMTiles renderer, and lazy GeoJSON renderer so documented direction ranges render at their actual widths.

## Root Cause

The Worker reduced range tags to midpoint bearings, client hydration dropped any span metadata, and both map renderers always used the legacy 50-degree cone width. PMTiles also serializes plural arrays as JSON strings, so the tile path needs compatible decoding before aligning widths by index.

## Execution Flow

```mermaid
flowchart TD
    A[Worker GeoJSON] --> B[Client hydration]
    B --> C[Marker cone helper]
    D[Hourly PMTiles] --> E[Tile cone helper]
    C --> F[Shared span resolver]
    E --> F
    F --> G[Span-aware polygons]
```

## Fix

- Publish Worker `directionSpan` and aligned `directionSpans` with the same compatibility rules as deflock-data.
- Retain span fields through FeatureCollection and legacy flat-array hydration.
- Resolve native and JSON-stringified plural metadata with independent 50-degree fallback per direction.
- Accept valid spans in `(0, 360]`; render zero, malformed, missing, or out-of-range spans with the legacy 50-degree width.
- Route both production renderers through tested tile and marker cone helpers.
- Add development source overrides and an exact three-camera fixture for reproducible PMTiles and GeoJSON checks.

Part of FoggedLens/deflock#145. Paired with the publisher PR: https://github.com/FoggedLens/deflock-data/pull/1

## Test plan

- [x] Root Vitest suite -- 253 tests pass across 27 files, including malformed singular/plural bearing rejection and span alignment.
- [x] Worker Vitest suite -- 99 tests pass across 9 files, including atomic rejection of non-finite tokens and derived range overflow.
- [x] Production build -- TypeScript and Vite build complete; 2,879 modules transformed.
- [x] ESLint on every touched file -- zero errors; one pre-existing unused-import warning remains in the Worker camera test.
- [x] Worker typecheck remains at the six pre-existing test-global diagnostics; no new diagnostics.
- [x] Main and Brand-filtered local PMTiles paths render all three fixture cameras and their direction polygons.
- [x] Lazy GeoJSON loads all three fixture cameras; marker cone geometry and timestamp preservation are covered by real-coordinate helper tests because Timeline Dot Density does not display cones.
- [x] Sabotage checks: removing Worker span publication caused six focused regressions; dropping the renderer span argument caused both tile helper tests to fail.
- [x] `git diff --check`.
